### PR TITLE
Upgrade embedded-hal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ repository = "https://github.com/byronwasti/rn4870"
 version = "0.1.0"
 
 [dependencies]
-embedded-hal = "0.1.0"
-nb = "0.1.1"
+embedded-hal = "0.2.4"
+nb = "0.1.2"


### PR DESCRIPTION
This upgrades embedded-hal to 0.2 and adds necessary changes to the lib code. This makes the library buildable on stable rust.