### PR TITLE
Multiple fixes / improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ repository = "https://github.com/byronwasti/rn4870"
 version = "0.2.0"
 
 [dependencies]
+bitflags = "1.2.1"
 embedded-hal = "0.2.4"
 nb = "0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,11 +141,12 @@ where
         self.blocking_write(&[b'\r']).map_err(|e| Error::Write(e))?;
 
         // Check for response
-        let mut buffer = [0; 4];
+        let mut buffer = [0; 10];
         self.blocking_read(&mut buffer[..])
             .map_err(|e| Error::Read(e))?;
 
-        if buffer == "AOK".as_bytes() {
+        // only if SR,<hex16> is set with 0x4000 (No prompt) then the prompt is not send
+        if buffer == "AOK\r\nCMD> ".as_bytes() {
             Ok(())
         } else {
             Err(Error::InvalidResponse)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
 //! Driver for the RN4870 BLE module
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate embedded_hal as hal;
 #[macro_use(block)]
 extern crate nb;
+#[macro_use(bitflags)]
+extern crate bitflags;
 
 use hal::blocking::delay::DelayMs;
 use hal::digital::v2::OutputPin;
@@ -23,6 +25,48 @@ pub enum Error<ER, EW, GpioError> {
 
     /// Invalid response from BLE module
     InvalidResponse,
+}
+
+bitflags! {
+    /// Services bit flags, see section 2.4.22
+    #[derive(Default)]
+    pub struct Services: u8 {
+        /// Device information
+        const DEVICE_INFORMATION    = 0b1000_0000;
+        /// UART Transparent
+        const UART_TRANSPARENT      = 0b0100_0000;
+        /// Beacon
+        const BEACON                = 0b0010_0000;
+        /// Reserved
+        const RESERVED              = 0b0001_0000;
+    }
+}
+
+impl<'a> Services {
+    /// biflags struct implements UpperHex trair however, not to include other dependencies to
+    /// do something like `uwrite!(s, "{:02X}", self.bits)` I decided to list all the possibilities
+    /// manually
+    pub fn as_str(self) -> &'a str {
+        match self.bits {
+            0b0000_0000 => "00",
+            0b0001_0000 => "10",
+            0b0010_0000 => "20",
+            0b0011_0000 => "30",
+            0b0100_0000 => "40",
+            0b0101_0000 => "50",
+            0b0110_0000 => "60",
+            0b0111_0000 => "70",
+            0b1000_0000 => "80",
+            0b1001_0000 => "90",
+            0b1010_0000 => "A0",
+            0b1011_0000 => "B0",
+            0b1100_0000 => "C0",
+            0b1101_0000 => "D0",
+            0b1110_0000 => "E0",
+            0b1111_0000 => "F0",
+            _ => unreachable!(),
+        }
+    }
 }
 
 /// Rn4870 Object
@@ -195,8 +239,8 @@ where
     }
 
     /// Set default services
-    pub fn set_default_services(&mut self, value: u8) -> Result<(), Error<ER, EW, GpioError>> {
-        self.send_command("SS", "C0")
+    pub fn set_services(&mut self, value: Services) -> Result<(), Error<ER, EW, GpioError>> {
+        self.send_command("SS", value.as_str())
     }
 
     pub fn send_raw(&mut self, values: &[u8]) -> Result<(), EW> {
@@ -209,5 +253,18 @@ where
 
     pub fn read_raw(&mut self) -> Result<u8, ER> {
         block!(self.uart.read())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_services_as_str() {
+        assert_eq!(&Services::empty().as_str(), &"00");
+        assert_eq!(
+            &(Services::UART_TRANSPARENT | Services::DEVICE_INFORMATION).as_str(),
+            &"C0"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ where
 
     /// Software reset, see section 2.6.28 of the User Guide (DS50002466C)
     pub fn soft_reset(&mut self) -> Result<(), Error<ER, EW, GpioError>> {
-        self.blocking_write(&[b'R', b',', b'1', b'\r'])
+        self.blocking_write(b"R,1\r")
             .map_err(|e| Error::Write(e))?;
 
         let mut buffer = [0; 19];
@@ -176,7 +176,7 @@ where
         self.blocking_read(&mut buffer[..])
             .map_err(|e| Error::Read(e))?;
 
-        if buffer != "Rebooting\r\n%REBOOT%".as_bytes() {
+        if buffer != b"Rebooting\r\n%REBOOT%" {
             Err(Error::InvalidResponse)
         } else {
             Ok(())
@@ -207,7 +207,7 @@ where
             .map_err(|e| Error::Read(e))?;
 
         // only if SR,<hex16> is set with 0x4000 (No prompt) then the prompt is not send
-        if buffer == "AOK\r\nCMD> ".as_bytes() {
+        if buffer == b"AOK\r\nCMD> " {
             Ok(())
         } else {
             Err(Error::InvalidResponse)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,23 @@ where
         Ok(())
     }
 
+    /// Software reset, see section 2.6.28 of the User Guide (DS50002466C)
+    pub fn soft_reset(&mut self) -> Result<(), Error<ER, EW, GpioError>> {
+        self.blocking_write(&[b'R', b',', b'1', b'\r'])
+            .map_err(|e| Error::Write(e))?;
+
+        let mut buffer = [0; 19];
+
+        self.blocking_read(&mut buffer[..])
+            .map_err(|e| Error::Read(e))?;
+
+        if buffer != "Rebooting\r\n%REBOOT%".as_bytes() {
+            Err(Error::InvalidResponse)
+        } else {
+            Ok(())
+        }
+    }
+
     fn send_command(
         &mut self,
         command: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ where
         self.blocking_write(&[b'\r']).map_err(|e| Error::Write(e))?;
 
         // Check for response
-        let mut buffer = [0; 3];
+        let mut buffer = [0; 4];
         self.blocking_read(&mut buffer[..])
             .map_err(|e| Error::Read(e))?;
 
@@ -152,16 +152,28 @@ where
         }
     }
 
-    /// Set the BLE name
+    /// Sets a serialized Bluetooth name for the device
     ///
     /// This function only works when in Command Mode.
-    pub fn set_name(&mut self, name: &str) -> Result<(), Error<ER, EW, GpioError>> {
+    pub fn set_serialized_name(&mut self, name: &str) -> Result<(), Error<ER, EW, GpioError>> {
         // Name must be less than 15 characters
         if name.as_bytes().len() > 15 {
             panic!("Invalid name length");
         }
 
         self.send_command("S-", name)
+    }
+    ///
+    /// Sets the device name
+    ///
+    /// This function only works when in Command Mode.
+    pub fn set_name(&mut self, name: &str) -> Result<(), Error<ER, EW, GpioError>> {
+        // Name must be less than 20 characters
+        if name.as_bytes().len() > 20 {
+            panic!("Invalid name length");
+        }
+
+        self.send_command("SN", name)
     }
 
     /// Set default services


### PR DESCRIPTION
I hope I was able to split to meaningful commits but I feel like 0883760 still needs explanation: When command is send, and is correct, RN4870 replies with `AOK\r`, but also by default will output next cmd prompt (`\nCMD>` by default) and I think that this needs to be read too (or. e.g. when using with STM32 chips this will return `Overrun` error). In the best case this should be configurable and I'll add it at some point, but for now this smaller change makes multiple consecutive `send_command` calls work.

Also - sorry for a strawman solution in df9de1c (`Services::as_str`), I will improve that in future, but for now this felt fastest way how to do and not so dirty.